### PR TITLE
Remove required trkref in ping setup

### DIFF
--- a/lib/reevoo-ping.js
+++ b/lib/reevoo-ping.js
@@ -9,10 +9,6 @@ import Badge from './events/badge';
 
 class Client {
   constructor(opts) {
-    validate(opts, {
-      trkref: { presence: true },
-    });
-
     this.experiences = new Experiences();
     this.page = new Page();
     this.badge = new Badge(opts.trkref);

--- a/spec/reevoo-ping.spec.js
+++ b/spec/reevoo-ping.spec.js
@@ -6,12 +6,6 @@ describe('lib/reevoo-ping', () => {
   });
 
   describe('.constructor', () => {
-    it('throws an error if the trkref is not given', () => {
-      expect(() => {
-        new ReevooPing.Client({}); // eslint-disable-line no-new
-      }).toThrowError(/Trkref/);
-    });
-
     it('returns object with valid options', () => {
       expect(() => {
         new ReevooPing.Client({ trkref: 'TRKREF' }); // eslint-disable-line no-new


### PR DESCRIPTION
We don't need it in experiences
Other apps can still optionally use it