### PR TITLE
Support badge.clicked tracking; Badge class refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # Built by webpack
 dist/*
+
+# Atom editor
+.tags*

--- a/lib/events/badge.js
+++ b/lib/events/badge.js
@@ -6,23 +6,28 @@ import stringify  from 'json-stable-stringify';
 import snowplow   from '../snowplow';
 import validate   from '../validate';
 
-const EVENT_TYPES     = ['rendered', 'seen'];
+const EVENT_TYPES     = ['rendered', 'seen', 'clicked'];
 const CONTENT_TYPES   = ['reviewable', 'customer_experience', 'conversations'];
 const HIT_TYPES       = ['impression', 'non_impression', 'miss'];
 const CTA_PAGE_USES   = ['single_reviewable', 'multi_reviewable'];
 const IMPLEMENTATIONS = ['link', 'custom_element'];
 
-const VALIDATIONS = {
-  eventType:          { presence: true, inclusion: EVENT_TYPES },
-  contentType:        { presence: true, inclusion: CONTENT_TYPES },
-  hitType:            { presence: true, inclusion: HIT_TYPES },
-  ctaPageUse:         { presence: true, inclusion: CTA_PAGE_USES },
-  implementation:     { presence: true, inclusion: IMPLEMENTATIONS },
-  trkref:             { presence: true },
-  ctaStyle:           { presence: false },
-  reviewableContext:  { presence: false },
-};
-const PROPERTIES = Object.keys(VALIDATIONS);
+function validationsForEventType(eventType) {
+  return {
+    eventType:          { presence: true, inclusion: EVENT_TYPES },
+    contentType:        { presence: true, inclusion: CONTENT_TYPES },
+    hitType:            { presence: eventType !== 'clicked', inclusion: HIT_TYPES },
+    ctaPageUse:         { presence: true, inclusion: CTA_PAGE_USES },
+    implementation:     { presence: true, inclusion: IMPLEMENTATIONS },
+    trkref:             { presence: true },
+    ctaStyle:           { presence: false },
+    reviewableContext:  { presence: false },
+  };
+}
+
+function propertiesForEventType(eventType) {
+  return Object.keys(validationsForEventType(eventType));
+}
 
 // To maintain backward compatibility we try to determine CTA page use when not provided.
 function determineCtaPageUse(opts) {
@@ -47,42 +52,50 @@ function snowplowData(that, eventProperties, additionalProperties) {
   };
 }
 
-function badgeEvent(that, eventType, props) {
-  const eventProperties = { eventType };
-  const additionalProperties = {};
-
-  for (const prop in props) {
-    if (PROPERTIES.indexOf(prop) === -1) {
-      additionalProperties[prop] = props[prop];
-    } else {
-      eventProperties[prop] = props[prop];
-    }
-  }
-
-  const data = snowplowData(that, eventProperties, additionalProperties);
-
-  validate(data, VALIDATIONS);
-
-  snowplow('trackUnstructEvent', {
-    schema: 'iglu:com.reevoo/badge_event/jsonschema/1-0-0',
-    data:   data,
-  });
-}
-
 
 export default class Badge {
   constructor(trkref) {
     this.trkref = trkref;
   }
 
+  track(eventType, props) {
+    const properties = propertiesForEventType(eventType);
+    const eventProperties = { eventType };
+    const additionalProperties = {};
+
+    for (const prop in props) {
+      if (properties.indexOf(prop) === -1) {
+        additionalProperties[prop] = props[prop];
+      } else {
+        eventProperties[prop] = props[prop];
+      }
+    }
+
+    const data = snowplowData(this, eventProperties, additionalProperties);
+
+    validate(data, validationsForEventType(eventType));
+
+    snowplow('trackUnstructEvent', {
+      schema: 'iglu:com.reevoo/badge_event/jsonschema/1-0-0',
+      data:   data,
+    });
+  }
+
+  // Shortcut methods:
+
   // To be triggered when a badge is rendered on the page.
   rendered(props) {
-    badgeEvent(this, 'rendered', props);
+    this.track('rendered', props);
   }
 
   // To be triggered when a badge enters the user's viewport. (Kinky.)
   seen(props) {
-    badgeEvent(this, 'seen', props);
+    this.track('seen', props);
+  }
+
+  // To be triggered when a badge is clicked.
+  clicked(props) {
+    this.track('clicked', props);
   }
 
 }

--- a/spec/events/badge.spec.js
+++ b/spec/events/badge.spec.js
@@ -22,11 +22,11 @@ describe('lib/events/badge', () => {
   });
 
 
-  describe('.rendered', () => {
-    let badgeRenderedParams;
+  describe('.track', () => {
+    let badgeEventParams;
 
     beforeEach(() => {
-      badgeRenderedParams = {
+      badgeEventParams = {
         hitType: 'impression',
         trkref: 'TRKREF',
         reviewableContext: { sku: 'SKU' },
@@ -39,13 +39,13 @@ describe('lib/events/badge', () => {
     });
 
     it('calls Snowplow', () => {
-      badge.rendered(badgeRenderedParams);
+      badge.rendered(badgeEventParams);
       expect(snowplow).toHaveBeenCalledWith(
         'trackUnstructEvent',
         jasmine.objectContaining({
           schema: 'iglu:com.reevoo/badge_event/jsonschema/1-0-0',
           data: jasmine.objectContaining({
-            ...omit(badgeRenderedParams, 'averageScore', 'reviewableContext'),
+            ...omit(badgeEventParams, 'averageScore', 'reviewableContext'),
             eventType: 'rendered',
             reviewableContext: '{"sku":"SKU"}',
             additionalProperties: '{"averageScore":9.2}',
@@ -55,40 +55,40 @@ describe('lib/events/badge', () => {
     });
 
     it('reports an error if hit type is not supplied', () => {
-      badgeRenderedParams.hitType = undefined;
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.hitType = undefined;
+      badge.rendered(badgeEventParams);
       expectItReportsError(/Hit type/);
     });
 
     it('reports an error if hit type is not valid', () => {
-      badgeRenderedParams.hitType = 'NOT_A_REAL_HIT_TYPE';
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.hitType = 'NOT_A_REAL_HIT_TYPE';
+      badge.rendered(badgeEventParams);
       expectItReportsError(/not included in the list/);
     });
 
     it('reports an error if content type is not supplied', () => {
-      badgeRenderedParams.contentType = undefined;
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.contentType = undefined;
+      badge.rendered(badgeEventParams);
       expectItReportsError(/Content type/);
     });
 
     it('reports an error if content type is not valid', () => {
-      badgeRenderedParams.contentType = 'NOT_A_REAL_CONTENT_TYPE';
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.contentType = 'NOT_A_REAL_CONTENT_TYPE';
+      badge.rendered(badgeEventParams);
       expectItReportsError(/not included in the list/);
     });
 
     it('reports an error if trkref is not supplied', () => {
-      badgeRenderedParams.trkref = undefined;
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.trkref = undefined;
+      badge.rendered(badgeEventParams);
       expectItReportsError(/Trkref/);
     });
 
     it('uses TRKREF from the root scope when not provided as argument', () => {
-      badgeRenderedParams.trkref = undefined;
+      badgeEventParams.trkref = undefined;
       badge = new Badge('MY_TRKREF');
 
-      badge.rendered(badgeRenderedParams);
+      badge.rendered(badgeEventParams);
       expect(snowplow).toHaveBeenCalledWith(
         jasmine.anything(),
         jasmine.objectContaining({
@@ -100,13 +100,13 @@ describe('lib/events/badge', () => {
     });
 
     it('reports an error if ctaPageUse is not valid', () => {
-      badgeRenderedParams.ctaPageUse = 'NOT_A_REAL_PAGE_USE';
-      badge.rendered(badgeRenderedParams);
+      badgeEventParams.ctaPageUse = 'NOT_A_REAL_PAGE_USE';
+      badge.rendered(badgeEventParams);
       expectItReportsError(/not included in the list/);
     });
 
     it('sorts and stringifies reviewable context', () => {
-      badge.rendered({ ...badgeRenderedParams, reviewableContext: { model: 'Focus', manufacturer: 'Ford' }});
+      badge.rendered({ ...badgeEventParams, reviewableContext: { model: 'Focus', manufacturer: 'Ford' }});
 
       expect(snowplow).toHaveBeenCalledWith(
         jasmine.anything(),
@@ -120,7 +120,7 @@ describe('lib/events/badge', () => {
 
     describe('determines CTA page use', () => {
       it('uses multi_reviewable if badgeVariant contains listing', () => {
-        badge.rendered({ ...badgeRenderedParams, ctaPageUse: undefined, badgeVariant: 'my_listing123' });
+        badge.rendered({ ...badgeEventParams, ctaPageUse: undefined, badgeVariant: 'my_listing123' });
 
         expect(snowplow).toHaveBeenCalledWith(
           jasmine.anything(),
@@ -133,7 +133,7 @@ describe('lib/events/badge', () => {
       });
 
       it('uses multi_reviewable if badgeVariant contains category', () => {
-        badge.rendered({ ...badgeRenderedParams, ctaPageUse: undefined, badgeVariant: 'my_category123' });
+        badge.rendered({ ...badgeEventParams, ctaPageUse: undefined, badgeVariant: 'my_category123' });
 
         expect(snowplow).toHaveBeenCalledWith(
           jasmine.anything(),
@@ -146,7 +146,7 @@ describe('lib/events/badge', () => {
       });
 
       it('uses single_reviewable otherwise', () => {
-        badge.rendered({ ...badgeRenderedParams, ctaPageUse: undefined, badgeVariant: 'my_foo123' });
+        badge.rendered({ ...badgeEventParams, ctaPageUse: undefined, badgeVariant: 'my_foo123' });
 
         expect(snowplow).toHaveBeenCalledWith(
           jasmine.anything(),
@@ -161,7 +161,7 @@ describe('lib/events/badge', () => {
 
     describe('determines CTA style', () => {
       it('uses badgeName if available', () => {
-        badge.rendered({ ...badgeRenderedParams, ctaStyle: undefined, badgeName: 'my_badge', badgeVariant: 'default' });
+        badge.rendered({ ...badgeEventParams, ctaStyle: undefined, badgeName: 'my_badge', badgeVariant: 'default' });
 
         expect(snowplow).toHaveBeenCalledWith(
           jasmine.anything(),
@@ -174,7 +174,7 @@ describe('lib/events/badge', () => {
       });
 
       it('uses badgeVariant if badgeName not available', () => {
-        badge.rendered({ ...badgeRenderedParams, ctaStyle: undefined, badgeName: undefined, badgeVariant: 'default' });
+        badge.rendered({ ...badgeEventParams, ctaStyle: undefined, badgeName: undefined, badgeVariant: 'default' });
 
         expect(snowplow).toHaveBeenCalledWith(
           jasmine.anything(),
@@ -184,6 +184,21 @@ describe('lib/events/badge', () => {
             }),
           })
         );
+      });
+    });
+  });
+
+
+  describe('shortcut methods', () => {
+    const testParams = { foo: 'bar '};
+
+    ['rendered', 'seen', 'clicked'].forEach((eventType) => {
+      describe(`.${eventType}`, () => {
+        it('calls track method', () => {
+          const trackMethod = spyOn(badge, 'track');
+          badge[eventType](testParams);
+          expect(trackMethod).toHaveBeenCalledWith(eventType, testParams);
+        });
       });
     });
   });


### PR DESCRIPTION
`badge.clicked` method expects the same attributes as `badge.rendered` except of `hitType`