### PR TITLE
Handle also page URLs violating RFC 2396

### DIFF
--- a/lib/reevoo-ping.js
+++ b/lib/reevoo-ping.js
@@ -12,12 +12,19 @@ import Badge                  from './events/badge';
 import Conversion             from './events/conversion';
 
 class Client {
-  constructor(appId, opts = {}, trackerConfig = {}) {
+  constructor(appId, opts = {}, trackerConfig = {}, win = window) {
     if (!appId) throw new Error('appId argument is required');
 
     // Initialise the tracker
     const snowplowTrackerConfig = { ...defaultSnowplowConfig, ...trackerConfig, appId };
     snowplow('newTracker', appId, COLLECTOR_URI, snowplowTrackerConfig);
+
+    // Snowplow collector cannot handle URLs with characters violating RFC 2396, if customer URL contains some of
+    // them we set our custom encoded version to be tracked.
+    const encodedURI = encodeURI(win.location.href).replace(/!/g, '%21');
+    if (encodedURI !== win.location.href) {
+      snowplow('setCustomUrl', encodedURI);
+    }
 
     // Tracker bounded to the current instance of Client (to support multiple instances with diferrent appId)
     const boundedTracker = (command, ...args) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reevoo-ping.js",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Reevoo-specific event sending client.",
   "main": "dist/reevoo-ping.js",
   "files": [

--- a/spec/reevoo-ping.spec.js
+++ b/spec/reevoo-ping.spec.js
@@ -84,6 +84,18 @@ describe('lib/reevoo-ping', () => {
           data: jasmine.objectContaining({ trkref: 'OTHER_TRKREF' }),
         }]);
       });
+
+      it('encodes URL if contains charactes violating RFC 2396', () => {
+        const win = { location: { href: 'http://sample.com/!"lol"!' } };
+        ping = new ReevooPing.Client('app-name', { trkref: 'TRKREF' }, {}, win);
+        ping.trackEvent({ type: 'TYPE', trkref: 'OTHER_TRKREF' });
+        expect(snowplow.calls.count()).toEqual(4); // first two are tracker init
+        expect(snowplow.calls.argsFor(2)).toEqual(['setCustomUrl', 'http://sample.com/%21%22lol%22%21']);
+        expect(snowplow.calls.argsFor(3)).toEqual(['trackUnstructEvent:app-name', {
+          schema: 'iglu:com.reevoo/generic_event/jsonschema/1-0-0',
+          data: jasmine.objectContaining({ trkref: 'OTHER_TRKREF' }),
+        }]);
+      });
     });
   });
 });


### PR DESCRIPTION
Snowplow collector cannot handle URLs with characters violating RFC 2396, if customer URL contains some of them we set our custom encoded version to be tracked.